### PR TITLE
debug links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,8 +7,6 @@ disqusShortname:
 googleAnalytics: ''
 summaryLength: 70
 paginate: 10
-relativeURLs: true
-uglyURLs: true
 markup:
   goldmark:
     renderer:


### PR DESCRIPTION
took out element for local view of website, as it does not work on built website.

will still have that in the release branch, probably.